### PR TITLE
More convenient way to call async methods on hub

### DIFF
--- a/SignalR.Client.TypedHubProxy/ITypedHubProxy.cs
+++ b/SignalR.Client.TypedHubProxy/ITypedHubProxy.cs
@@ -33,11 +33,25 @@ namespace Microsoft.AspNet.SignalR.Client
         Task CallAsync(Expression<Action<TServerHubInterface>> call);
 
         /// <summary>
+        ///     Calls an asynchronous method on the server hub.
+        ///     <para>This call will be executed asynchronously.</para>
+        /// </summary>
+        /// <param name="call">The asynchronous method to call. Use like: <code>hub => hub.MyMethod("param1", "param2")</code></param>
+        Task CallAsync(Expression<Func<TServerHubInterface, Task>> call);
+
+        /// <summary>
         ///     Calls a method on the server hub.
         ///     <para>This call will be executed asynchronously. A task will be returned which contains the response.</para>
         /// </summary>
         /// <param name="call">The method to call. Use like: <code>hub => hub.MyMethod("param1", "param2")</code></param>
         Task<TResult> CallAsync<TResult>(Expression<Func<TServerHubInterface, TResult>> call);
+
+        /// <summary>
+        ///     Calls an asynchronous method on the server hub.
+        ///     <para>This call will be executed asynchronously. A task will be returned which contains the response.</para>
+        /// </summary>
+        /// <param name="call">The asynchronous method to call. Use like: <code>hub => hub.MyMethod("param1", "param2")</code></param>
+        Task<TResult> CallAsync<TResult>(Expression<Func<TServerHubInterface, Task<TResult>>> call);
 
         /// <summary>
         ///     Subscribes to a hub event.

--- a/SignalR.Client.TypedHubProxy/TypedHubProxy.cs
+++ b/SignalR.Client.TypedHubProxy/TypedHubProxy.cs
@@ -74,8 +74,22 @@ namespace Microsoft.AspNet.SignalR.Client
             return _hubProxy.Invoke(invocation.MethodName, invocation.Parameters);
         }
 
+        Task ITypedHubProxy<TServerHubInterface, TClientInterface>.CallAsync(
+            Expression<Func<TServerHubInterface, Task>> call)
+        {
+            ActionDetail invocation = call.GetActionDetails();
+            return _hubProxy.Invoke(invocation.MethodName, invocation.Parameters);
+        }
+
         Task<TResult> ITypedHubProxy<TServerHubInterface, TClientInterface>.CallAsync<TResult>(
             Expression<Func<TServerHubInterface, TResult>> call)
+        {
+            ActionDetail invocation = call.GetActionDetails();
+            return _hubProxy.Invoke<TResult>(invocation.MethodName, invocation.Parameters);
+        }
+
+        Task<TResult> ITypedHubProxy<TServerHubInterface, TClientInterface>.CallAsync<TResult>(
+            Expression<Func<TServerHubInterface, Task<TResult>>> call)
         {
             ActionDetail invocation = call.GetActionDetails();
             return _hubProxy.Invoke<TResult>(invocation.MethodName, invocation.Parameters);


### PR DESCRIPTION
Hello! I think it would be useful to have the ability to call async methods on a hub.

Added two additional overloads for CallAsync method:
1) To call hub's methods which return Task
2) To call hub's methods which return Task&lt;T&gt;
All the magic is handled by SignalR.

Thank you for your library!
