### PR TITLE
Better exception on SubscribeOnAll

### DIFF
--- a/src/SignalR.Client.TypedHubProxy.Tests/Contracts/IWrongClientContract.cs
+++ b/src/SignalR.Client.TypedHubProxy.Tests/Contracts/IWrongClientContract.cs
@@ -1,0 +1,10 @@
+﻿using JetBrains.Annotations;
+
+namespace SignalR.Client.TypedHubProxy.Tests.Contracts
+{
+    [PublicAPI]
+    public interface IWrongClientContract
+    {
+        object PassingNoParams();
+    }
+}

--- a/src/SignalR.Client.TypedHubProxy.Tests/Contracts/WrongClientContract.cs
+++ b/src/SignalR.Client.TypedHubProxy.Tests/Contracts/WrongClientContract.cs
@@ -1,0 +1,10 @@
+﻿namespace SignalR.Client.TypedHubProxy.Tests.Contracts
+{
+    class WrongClientContract : IWrongClientContract
+    {
+        public object PassingNoParams()
+        {
+            return new { };
+        }
+    }
+}

--- a/src/SignalR.Client.TypedHubProxy.Tests/HubProxyFacts.cs
+++ b/src/SignalR.Client.TypedHubProxy.Tests/HubProxyFacts.cs
@@ -235,6 +235,16 @@ namespace SignalR.Client.TypedHubProxy.Tests
             subscriptions?.ToList().ForEach(s => s.Dispose());
         }
 
+        [Fact]
+        public void TestSubscribeOnAllShouldFailWhenTheClientInterfaceHasFunc()
+        {
+            var clientContract = new WrongClientContract();
+            IEnumerable<IDisposable> subscriptions = null;
+            Action act = () => subscriptions = _fixture.WrongProxy.SubscribeOnAll(clientContract)?.ToList();
+
+            act.ShouldThrow<NotSupportedException>();
+        }
+
         /// <summary>
         ///     Test bugfix for issue #9.
         /// </summary>

--- a/src/SignalR.Client.TypedHubProxy.Tests/SignalR.Client.TypedHubProxy.Tests.csproj
+++ b/src/SignalR.Client.TypedHubProxy.Tests/SignalR.Client.TypedHubProxy.Tests.csproj
@@ -98,7 +98,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Contracts\IWrongClientContract.cs" />
     <Compile Include="Contracts\TestClientContract.cs" />
+    <Compile Include="Contracts\WrongClientContract.cs" />
     <Compile Include="TestFixtures\BaseFixture.cs" />
     <Compile Include="TestFixtures\ObservableHubProxyFixture.cs" />
     <Compile Include="TestFixtures\TypedHubProxyFixture.cs" />

--- a/src/SignalR.Client.TypedHubProxy.Tests/TestFixtures/TypedHubProxyFixture.cs
+++ b/src/SignalR.Client.TypedHubProxy.Tests/TestFixtures/TypedHubProxyFixture.cs
@@ -8,8 +8,11 @@ namespace SignalR.Client.TypedHubProxy.Tests.TestFixtures
         public TypedHubProxyFixture()
         {
             Proxy = HubProxyMock.Object.AsHubProxy<IServerContract, IClientContract>();
+            WrongProxy = HubProxyMock.Object.AsHubProxy<IServerContract, IWrongClientContract>();
         }
 
         public IHubProxy<IServerContract, IClientContract> Proxy { get; private set; }
+
+        public IHubProxy<IServerContract, IWrongClientContract> WrongProxy { get; private set; }
     }
 }

--- a/src/SignalR.Client.TypedHubProxy/HubProxy.cs
+++ b/src/SignalR.Client.TypedHubProxy/HubProxy.cs
@@ -227,14 +227,20 @@ namespace Microsoft.AspNet.SignalR.Client
             foreach (var methodInfo in methodInfos)
             {
                 var parameterInfos = methodInfo.GetParameters();
+                var declaringType = methodInfo.DeclaringType?.FullName.Replace("+", ".");
 
                 if (parameterInfos.Count() > 7)
                 {
-                    var declaringType = methodInfo.DeclaringType?.FullName.Replace("+", ".");
                     var methodParameters = string.Join(", ",
                         methodInfo.GetParameters().Select(p => $"{p.ParameterType.Name} {p.Name}"));
                     throw new NotSupportedException(
                         $"Only interface methods with less or equal 7 parameters are supported: {declaringType}.{methodInfo.Name}({methodParameters})!");
+                }
+
+                if (methodInfo.ReturnType != typeof(void))
+                {
+                    throw new NotSupportedException(
+                        $"Interface methods of the client should return void, but the method \"{declaringType}.{methodInfo.Name}\" returns \"{methodInfo.ReturnType.Name}\".");
                 }
 
                 var actionType = Expression.GetActionType(parameterInfos.Select(p => p.ParameterType).ToArray());


### PR DESCRIPTION
I struggled all day trying to understand why SubscribeOnAll was sending me the cryptic message "Cannot bind to the target method because its signature or security transparency is not compatible with that of the delegate type.".

I eventually understood that the issue was in my client interface, that defined a method with a return value.
My fault was designing my client interface the same way I am designing the server one. It makes sense for the server to send a response as a return value, but the client is actually unable to do that.
It is easy to forget the later, though, and expect the client to be able to send data back to the server.

So for the sake of saving future programmers from trying to find what's wrong, I added a more explicit exception (and the unit test that goes with it):

`NotSupportedException: Interface methods of the client should return void, but the method "<method>" returns "<return type>".`

I hope it'll save some precious time to other signalr programmers :)